### PR TITLE
Set tree nodes to be the full width of the parent container

### DIFF
--- a/src/components/VanillaTreeViewer/Helpers/setTreeNodeToFullWidth.js
+++ b/src/components/VanillaTreeViewer/Helpers/setTreeNodeToFullWidth.js
@@ -1,0 +1,30 @@
+/*
+ * The tree nodes need to have their width set to full width of
+ * their parent container. This is so the background highlighting extends
+ * all the way across the container.
+ *
+ * Since the parent has `overflow: scroll`, setting the
+ * children to `width: 100%` does not account the full hidden/scroll width.
+ *
+ * There's no good programmatic way to set this via CSS. We could use an
+ * inline `calc(100% + X)` on each child but that doesn't scale when
+ * the indentend folders are deeply nested (e.g. > 5 levels).
+ *
+ * Ultimately the approach is to use a few lines of JavaScript to
+ * programmatically set this. This needs to be executed *after* the elements
+ * have been rendered so that we can fetch the `scrollWidth` of the parent container
+ */
+function setTreeNodeToFullWidth() {
+  const tree = document.querySelector('.vanilla-tree-viewer__tree');
+  if (!tree) {
+    return;
+  }
+
+  document
+    .querySelectorAll('.vanilla-tree-viewer__tree-node')
+    .forEach((element) => {
+      element.style.width = `${tree.scrollWidth}px`;
+    });
+}
+
+export default setTreeNodeToFullWidth;

--- a/src/components/VanillaTreeViewer/Tree/Tree.scss
+++ b/src/components/VanillaTreeViewer/Tree/Tree.scss
@@ -23,7 +23,8 @@
   flex-wrap: nowrap;
   align-items: stretch;
   justify-content: flex-start;
-  height: 18px;
+  box-sizing: border-box;
+  height: 30px;
   padding: 6px 0;
   cursor: pointer;
 

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.js
@@ -8,6 +8,7 @@ import Component from 'lib/Component';
 import defaultSelectedPath from './Helpers/defaultSelectedPath';
 import { hljsStyleUrl } from './hljs';
 import { renderComponent } from './Helpers/renderComponent';
+import setTreeNodeToFullWidth from './Helpers/setTreeNodeToFullWidth';
 import Store from 'lib/Store/Store';
 import { validateFiles } from './Validator/Validator';
 
@@ -27,6 +28,7 @@ class VanillaTreeViewer extends Component {
     this.renderIntoDOM = this.renderIntoDOM.bind(this);
     this.renderComponent = this.renderComponent.bind(this);
     this.renderInvalid = this.renderInvalid.bind(this);
+    this.afterRender = this.afterRender.bind(this);
     this.render = this.render.bind(this);
 
     const validationResult = validateFiles(files);
@@ -153,11 +155,17 @@ class VanillaTreeViewer extends Component {
     return renderComponent(InvalidState, { reason: errorText });
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  afterRender() {
+    setTreeNodeToFullWidth();
+  }
+
   render() {
     const { errorText } = this.store.state;
     const content = errorText ? this.renderInvalid() : this.renderComponent();
 
     this.renderIntoDOM(content);
+    this.afterRender();
   }
 }
 

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
@@ -290,6 +290,15 @@ describe('<VanillaTreeViewer />', () => {
       )[0];
       expect(path.innerText).to.equal('/gamma.rb');
     });
+
+    describe('after rendering', () => {
+      it('sets the tree node as full-width', async () => {
+        render();
+        await waitUntil(hasRenderedCode);
+
+        expectAllNodesToBeFullWidth();
+      });
+    });
   });
 
   describe('switching between files', () => {
@@ -322,6 +331,19 @@ describe('<VanillaTreeViewer />', () => {
       expect(codeTag.innerHTML).to.equal(
         "const foo = () =&gt; { alert('foo'); }"
       );
+    });
+
+    describe('after rendering', () => {
+      it('sets the tree node as full-width', async () => {
+        render();
+        await waitUntil(hasRenderedCode);
+
+        const secondFile = findTreeNodeByPath('/delta/epsilon.js');
+        secondFile.click();
+        await waitUntil(hasRenderedCode);
+
+        expectAllNodesToBeFullWidth();
+      });
     });
 
     describe('validation and error handling', () => {
@@ -411,6 +433,23 @@ describe('<VanillaTreeViewer />', () => {
         '/gamma.rb'
       ]);
     });
+
+    describe('after rendering', () => {
+      it('sets the tree node as full-width', async () => {
+        render();
+        await waitUntil(hasRenderedCode);
+
+        const directory = findTreeNodeByPath('/delta');
+
+        // Collapse directory
+        directory.click();
+        expectAllNodesToBeFullWidth();
+
+        // Expand directory
+        directory.click();
+        expectAllNodesToBeFullWidth();
+      });
+    });
   });
 });
 
@@ -430,6 +469,19 @@ const displayedNodePaths = () => {
   }
 
   return paths;
+};
+
+const expectAllNodesToBeFullWidth = () => {
+  const scrollWidth = document.querySelector(
+    '.vanilla-tree-viewer__tree'
+  ).scrollWidth;
+
+  const nodes = rendered().getElementsByClassName(
+    'vanilla-tree-viewer__tree-node'
+  );
+  for (let i = 0; i < nodes.length; i++) {
+    expect(nodes[i].style.width).equal(`${scrollWidth}px`);
+  }
 };
 
 const findTreeNodeByPath = (path) => {


### PR DESCRIPTION
This makes the background highlight effect visually extend across the
entire directory tree.

Implementing this in native CSS is difficult since the parent's full
width can not easily be determined (since it is scrolled). Instead we
use JavaaScript to set the width after each render.