### PR TITLE
Using `overflow-*: auto` instead of `overflow-*: scroll`

### DIFF
--- a/src/components/VanillaTreeViewer/CodePanel/Code/Code.scss
+++ b/src/components/VanillaTreeViewer/CodePanel/Code/Code.scss
@@ -7,7 +7,7 @@
   // code panel. This also includes setting the
   // `<code>` tag to have full height below.
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
   font-size: 14px;
   line-height: 1.3;
 

--- a/src/components/VanillaTreeViewer/CodePanel/Header/Path/Path.scss
+++ b/src/components/VanillaTreeViewer/CodePanel/Header/Path/Path.scss
@@ -1,6 +1,6 @@
 .vtv__code-path {
   flex-grow: 1;
-  overflow-x: scroll;
+  overflow-x: auto;
   line-height: 30px;
   white-space: nowrap;
 }

--- a/src/components/VanillaTreeViewer/Tree/Tree.scss
+++ b/src/components/VanillaTreeViewer/Tree/Tree.scss
@@ -7,7 +7,7 @@
   height: 200px;
   margin: 0;
   padding: 20px 0;
-  overflow-x: scroll;
+  overflow-x: auto;
   white-space: nowrap;
   background-color: $wimbeldon_ridge;
 


### PR DESCRIPTION
Browsers on Windows display large ugly scroll bars by default.

`auto` will only display scroll bars if the content is overflowed, so at least it partially resolves the issue.