### PR TITLE
Add `contents` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ At the bottom of your page, include a `<script>` tag that defines the list of fi
     },
     {
       path: 'package.json',
-      url: 'https://raw.githubusercontent.com/axios/axios/master/package.json',
+      // Specify the file contents directly, instead of a URL
+      contents: '{ \"foo\": \"bar\" }',
       // Overrides the 'global' options below, just for this specific file
       options: { language: 'json' }
     }
@@ -190,8 +191,9 @@ Each file object can have the following keys:
 
 | Key  | Type | Required? | Description
 | ------------- | ------------- | ------------- | ------------- |
-| `url`  | `String` | Yes  | The URL to fetch the file contents from (e.g. Github Raw URLs). A simple GET request is performed to fetch file contents |
 | `path`  | `String` | Yes  | The path under which the file should be displayed in the viewer tree |
+| `url`  | `String` | One of `url`/`contents` required  | The URL to fetch the file contents from (e.g. Github Raw URLs). A simple GET request is performed to fetch file contents. |
+| `contents` | `String` | One of `url`/`contents` required | The file contents to be displayed. Takes precedence over `url` if both are set. |
 | `selected` | `Boolean` | No | Indicates whether this file should be selected when the viewer loads. If more than one file is marked `selected: true`, the first one is chosen. Similarly, if no file is marked `selected: true`, the first file in the list will be selected by default.
 | `options` | `Object{}` | No | File-level options that will apply only to this file. See `options` below for a full list of supported options |
 

--- a/src/components/VanillaTreeViewer/CodePanel/Code/Code.js
+++ b/src/components/VanillaTreeViewer/CodePanel/Code/Code.js
@@ -106,8 +106,9 @@ class Code {
     }
 
     /*
-     * If we don't have the file contents for this file cached,
-     * fetch it asynchronously and display `Loading` in the mean time
+     * If we don't have the file contents for this file already set
+     * or cached, fetch it asynchronously and display `Loading` in
+     * the mean time
      */
     if (!file.contents) {
       fetchFileContents(file.path);

--- a/src/components/VanillaTreeViewer/CodePanel/Code/Code.test.js
+++ b/src/components/VanillaTreeViewer/CodePanel/Code/Code.test.js
@@ -124,21 +124,58 @@ describe('<Code />', () => {
     });
   });
 
-  describe('file has no contents', () => {
-    beforeEach(() => {
-      file.contents = null;
+  describe('determining file contents', () => {
+    describe('file has `url` set, but not `contents`', () => {
+      beforeEach(() => {
+        file.contents = null;
+      });
+
+      it('calls fetchFileContents()', () => {
+        render();
+        expect(fetchFileContents.mock.calls.length).to.eql(1);
+      });
+
+      it('renders the Loading state', () => {
+        const loading = render();
+
+        expect(loading.classList.contains('vtv__code-loading')).to.be.true;
+        expect(loading.innerHTML).to.eql('Loading...');
+      });
     });
 
-    it('calls fetchFileContents()', () => {
-      render();
-      expect(fetchFileContents.mock.calls.length).to.eql(1);
+    describe('file has `contents` set, but not `url`', () => {
+      beforeEach(() => {
+        file.url = null;
+        file.contents = 'class Foo < Bar\nend';
+      });
+
+      it('does not call fetchFileContents()', () => {
+        render();
+        expect(fetchFileContents.mock.calls.length).to.eql(0);
+      });
+
+      it('does not render the Loading state', () => {
+        const loading = render();
+
+        expect(loading.classList.contains('vtv__code-loading')).to.be.false;
+      });
     });
 
-    it('renders the Loading state', () => {
-      const loading = render();
+    describe('both `contents` and `url` are set', () => {
+      beforeEach(() => {
+        file.contents = 'class Foo < Bar\nend';
+      });
 
-      expect(loading.classList.contains('vtv__code-loading')).to.be.true;
-      expect(loading.innerHTML).to.eql('Loading...');
+      it('does not call fetchFileContents()', () => {
+        render();
+        expect(fetchFileContents.mock.calls.length).to.eql(0);
+      });
+
+      it('does not render the Loading state', () => {
+        const loading = render();
+
+        expect(loading.classList.contains('vtv__code-loading')).to.be.false;
+      });
     });
   });
 

--- a/src/components/VanillaTreeViewer/Tree/Builder/Builder.js
+++ b/src/components/VanillaTreeViewer/Tree/Builder/Builder.js
@@ -17,8 +17,12 @@ function newTreeNode(type, name, path, file) {
   }
 
   if (type === 'file') {
-    // File contents will be fetched & populated later
-    treeNode.contents = null;
+    /*
+     * Upstream validations will guarantee that one of `url`
+     * or `contents` is present. If `contents` are blank, it
+     * will be fetched and populated from the `url` later.
+     */
+    treeNode.contents = file.contents || null;
     treeNode.url = file.url;
     treeNode.error = null;
     treeNode.options = file.options;

--- a/src/components/VanillaTreeViewer/Tree/Builder/Builder.test.js
+++ b/src/components/VanillaTreeViewer/Tree/Builder/Builder.test.js
@@ -81,6 +81,20 @@ describe('Builder.toDirectoryTree', () => {
     expect(tree).to.deep.equal(expected);
   });
 
+  describe('`contents` is specified instead of `url`', () => {
+    beforeEach(() => {
+      files[0].contents = 'class Foo < Bar\nend';
+    });
+
+    it('sets `contents`', () => {
+      const tree = toDirectoryTree(files, globalOptions);
+
+      expect(tree['/alpha/beta/gamma.rb'].contents).to.eql(
+        'class Foo < Bar\nend'
+      );
+    });
+  });
+
   describe('parsing paths', () => {
     it('handles paths case insensitively', () => {
       files[0].path = 'AlPhA/BeTA/gaMMa.rb';

--- a/src/components/VanillaTreeViewer/Validator/Validator.js
+++ b/src/components/VanillaTreeViewer/Validator/Validator.js
@@ -19,7 +19,16 @@ function allFilesHaveRequiredKey(files) {
     if (!file.path || (file.path || '').length === 0) {
       badFileCount += 1;
     }
-    if (!file.url || (file.url || '').length === 0) {
+  });
+
+  return badFileCount === 0;
+}
+
+function hasUrlOrContentsPresent(files) {
+  let badFileCount = 0;
+
+  files.forEach((file) => {
+    if ((file.url || '').length === 0 && (file.contents || '').length === 0) {
       badFileCount += 1;
     }
   });
@@ -90,7 +99,15 @@ function handleMissingFiles() {
 function handleFilesMissingRequiredKeys() {
   return {
     isValid: false,
-    error: 'Each `file` must have a non-empty `path` and `url`'
+    error: 'Each `file` must have a non-empty `path`'
+  };
+}
+
+function handleUrlOrContentsBlank() {
+  return {
+    isValid: false,
+    error:
+      'Each `file` must have at least one of the following set: `url`, `contents`'
   };
 }
 
@@ -136,6 +153,9 @@ function validateFiles(files) {
   }
   if (!allFilesHaveRequiredKey(files)) {
     return handleFilesMissingRequiredKeys();
+  }
+  if (!hasUrlOrContentsPresent(files)) {
+    return handleUrlOrContentsBlank();
   }
   if (!allFilesHaveUniquePaths(files)) {
     return handleFilesHaveDuplicatePaths();

--- a/src/components/VanillaTreeViewer/Validator/Validator.test.js
+++ b/src/components/VanillaTreeViewer/Validator/Validator.test.js
@@ -26,6 +26,18 @@ describe('Validator.validateFiles', () => {
     expect(result.isValid).to.be.true;
   });
 
+  describe('`contents` is specified instead of `url`', () => {
+    beforeEach(() => {
+      delete files[0].url;
+      files[0].contents = 'foo bar';
+    });
+
+    it('marks the files as valid', () => {
+      const result = validateFiles(files);
+      expect(result.isValid).to.be.true;
+    });
+  });
+
   const testForInvalid = () => {
     const result = validateFiles(files);
 
@@ -75,14 +87,6 @@ describe('Validator.validateFiles', () => {
     it('marks the files as invalid', testForInvalid);
   });
 
-  describe('one ore more files is missing `url`', () => {
-    beforeEach(() => {
-      delete files[1].url;
-    });
-
-    it('marks the files as invalid', testForInvalid);
-  });
-
   describe('one ore more files has null `path`', () => {
     beforeEach(() => {
       files[1].path = null;
@@ -91,9 +95,19 @@ describe('Validator.validateFiles', () => {
     it('marks the files as invalid', testForInvalid);
   });
 
-  describe('one ore more files has null `url`', () => {
+  describe('one ore more files has missing `url` AND `contents`', () => {
+    beforeEach(() => {
+      delete files[1].url;
+      delete files[1].contents;
+    });
+
+    it('marks the files as invalid', testForInvalid);
+  });
+
+  describe('one ore more files has null `url` AND `contents`', () => {
     beforeEach(() => {
       files[1].url = null;
+      files[1].contents = null;
     });
 
     it('marks the files as invalid', testForInvalid);

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
@@ -74,6 +74,44 @@ describe('<VanillaTreeViewer />', () => {
     ]);
   });
 
+  describe('determining file contents', () => {
+    it('fetches the file contents from the `url`', async () => {
+      files[0].url = 'https://example.co/path/to/gamma.rb';
+      files[0].contents = null;
+
+      render();
+      await waitUntil(hasRenderedCode);
+
+      const code = rendered().getElementsByClassName('vtv__code')[0];
+      const codeTag = code.getElementsByTagName('code')[0];
+      expect(codeTag.innerHTML).to.equal('def foo;true;end');
+    });
+
+    it('allows specifying file contents directly with `contents`', async () => {
+      files[0].url = null;
+      files[0].contents = 'def foo;nil;end';
+
+      render();
+      await waitUntil(hasRenderedCode);
+
+      const code = rendered().getElementsByClassName('vtv__code')[0];
+      const codeTag = code.getElementsByTagName('code')[0];
+      expect(codeTag.innerHTML).to.equal('def foo;nil;end');
+    });
+
+    it('The `contents` option takes precedence over `url`', async () => {
+      files[0].url = 'https://example.co/path/to/gamma.rb';
+      files[0].contents = 'def foo;nil;end';
+
+      render();
+      await waitUntil(hasRenderedCode);
+
+      const code = rendered().getElementsByClassName('vtv__code')[0];
+      const codeTag = code.getElementsByTagName('code')[0];
+      expect(codeTag.innerHTML).to.equal('def foo;nil;end');
+    });
+  });
+
   describe('rendering style', () => {
     it('renders the default style', async () => {
       render();


### PR DESCRIPTION
The displayed contents for each file are fetched from the specified `url`
option.

It is also convenient to have the ability to specify the raw file contents
directly. This is espcially true for smaller files, or if it is difficult to
host your file snippets under some remote URL.

This commit adds a `contents` option to which can be used to specify the
file contents inline.

# Usage

  ```
  <script>
    const files = [
      {
        path: 'lib/file.js',
        contents: 'const foo = () => {\n  alert('foo');\n}',
        language: 'javascript'
      }
    ];

    new VanillaTreeViewer('some-id', files).render();
  </script>
  ```

# Behavior

* This commit adds a validation to ensure at least one of `url` or `contents`
  is specified.
* This option takes precedence over `url` if both are specified