### PR TITLE
[Breaking Change] Combine global options into file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
 - [Configuration](#configuration)
   - [`id`](#config-id)
   - [`files`](#config-files)
-  - [`options`](#config-options)
 - [Customization](#customization)
   - [Configuring Width and Alignment](#configuring-width-and-alignment)
   - [Customizing Styling](#customizing-styling)
@@ -82,22 +81,18 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
   const files = [
     {
       path: 'lib/axios.js',
-      url: 'https://raw.githubusercontent.com/axios/axios/master/lib/axios.js'
+      url: 'https://raw.githubusercontent.com/axios/axios/master/lib/axios.js',
+      language: 'json'
     },
     {
       path: 'package.json',
       // Specify the file contents directly, instead of a URL
       contents: '{ \"foo\": \"bar\" }',
-      // Overrides the 'global' options below, just for this specific file
-      options: { language: 'json' }
+      language: 'json'
     }
   ];
 
-  new VanillaTreeViewer(
-    'my-viewer',
-    files,
-    { language: 'javascript' }
-  ).render();
+  new VanillaTreeViewer('my-viewer', files).render();
 </script>
 ```
 
@@ -146,7 +141,7 @@ For example, highlighting `ActionScript`:
 # <a name="configuration"></a>Configuration
 
 ```js
-var viewer = new VanillaTreeViewer(id, files, options);
+var viewer = new VanillaTreeViewer(id, files);
 viewer.render();
 ```
 
@@ -165,31 +160,17 @@ You can render multiple instances of the viewer, but keep in mind -
 
 Each file object can have the following keys:
 
-| Key  | Type | Required? | Description
-| ------------- | ------------- | ------------- | ------------- |
-| `path`  | `String` | Yes  | The path under which the file should be displayed in the viewer tree |
-| `url`  | `String` | One of `url`/`contents` required  | The URL to fetch the file contents from (e.g. Github Raw URLs). A simple GET request is performed to fetch file contents. |
-| `contents` | `String` | One of `url`/`contents` required | The file contents to be displayed. Takes precedence over `url` if both are set. |
-| `selected` | `Boolean` | No | Indicates whether this file should be selected when the viewer loads. If more than one file is marked `selected: true`, the first one is chosen. Similarly, if no file is marked `selected: true`, the first file in the list will be selected by default.
-| `options` | `Object{}` | No | File-level options that will apply only to this file. See `options` below for a full list of supported options |
-
-
-### <a name="config-options"></a>`options`
-
-The `options` are -
-
-| Key  | Type | Default | Description
-| ------------- | ------------- | ------------- | ------------- |
-| `language` | `String` | `null` | The `highlight.js` language to use for syntax highlighting. [See a full list of supported languages](https://github.com/highlightjs/highlight.js/tree/master/src/languages).
-| `style` | `String` | `'monokai-sublime'` | The `highlight.js` style (color theme) to use for syntax highlighting. [See a full list of supported styles](https://github.com/highlightjs/highlight.js/tree/master/src/styles).
+| Key  | Type | Required? | Default | Description
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+| `path`  | `String` | Yes | | The path under which the file should be displayed in the viewer tree |
+| `url`  | `String` | One of `url`/`contents` required | | The URL to fetch the file contents from (e.g. Github Raw URLs). A simple GET request is performed to fetch file contents. |
+| `contents` | `String` | One of `url`/`contents` required | | The file contents to be displayed. Takes precedence over `url` if both are set. |
+| `selected` | `Boolean` | No | | Indicates whether this file should be selected when the viewer loads. If more than one file is marked `selected: true`, the first one is chosen. Similarly, if no file is marked `selected: true`, the first file in the list will be selected by default.
+| `language` | `String` | No | `null` | The `highlight.js` language to use for syntax highlighting. [See a full list of supported languages](https://github.com/highlightjs/highlight.js/tree/master/src/languages).
+| `style` | `String` | No | `'monokai-sublime'` | The `highlight.js` style (color theme) to use for syntax highlighting. [See a full list of supported styles](https://github.com/highlightjs/highlight.js/tree/master/src/styles).
 
 **NOTE**: The [`highlight.js` demo page](https://highlightjs.org/static/demo/) will let you preview various languages and styles.
 
-Options can be defined per file or as a shared set of options passed to `VanillaTreeViewer`. For each file, options are evaluated in the following order of precedence:
-
-1. File level options
-2. Shared options
-3. Default options
 
 # <a name="customization"></a>Customization
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -3,22 +3,20 @@ import VanillaTreeViewer from '../src/components/VanillaTreeViewer/VanillaTreeVi
 const files = [
   {
     path: 'lib/core/transformData.js',
-    url: 'https://raw.githubusercontent.com/axios/axios/master/lib/core/transformData.js'
+    url: 'https://raw.githubusercontent.com/axios/axios/master/lib/core/transformData.js',
+    language: 'javascript'
   },
   {
     path: 'lib/axios.js',
-    url: 'https://raw.githubusercontent.com/axios/axios/master/lib/axios.js'
+    url: 'https://raw.githubusercontent.com/axios/axios/master/lib/axios.js',
+    language: 'javascript'
   },
   {
     path: 'package.json',
     url: 'https://raw.githubusercontent.com/axios/axios/master/package.json',
-    options: { language: 'json' }
+    language: 'json'
   }
 ];
 
-const options = {
-  language: 'javascript'
-}
-
-let viewer = new VanillaTreeViewer('app', files, options);
+let viewer = new VanillaTreeViewer('app', files);
 viewer.render();

--- a/src/components/VanillaTreeViewer/CodePanel/Code/Code.js
+++ b/src/components/VanillaTreeViewer/CodePanel/Code/Code.js
@@ -17,7 +17,7 @@ class Code {
   namespacedCss() {
     const { file, namespace, syntaxHighlightStyles } = this.props;
 
-    if (!file.options || !file.options.style) {
+    if (!file.style) {
       return null;
     }
 
@@ -36,7 +36,7 @@ class Code {
      *   Output: #someId.hljs.foo { background-color: black; }
      *
      */
-    const css = syntaxHighlightStyles[file.options.style];
+    const css = syntaxHighlightStyles[file.style];
 
     return css.replace(/\.hljs/gu, `#${namespace} .hljs`);
   }
@@ -44,7 +44,7 @@ class Code {
   highlightedContents() {
     const { file } = this.props;
 
-    if (!file.options || !file.options.language) {
+    if (!file.language) {
       return file.contents;
     }
 
@@ -52,7 +52,7 @@ class Code {
      * Use `hljs` to apply highlighting markup to the file contents
      * See: https://highlightjs.readthedocs.io/en/latest/api.html#highlight-languagename-code-ignore-illegals-continuation
      */
-    return hljs.highlight(file.options.language, file.contents).value;
+    return hljs.highlight(file.language, file.contents).value;
   }
 
   renderComponent() {
@@ -119,8 +119,8 @@ class Code {
      * If a CSS style was specified and we don't have it cached,
      * fetch it asynchronously and display `Loading` in the mean time
      */
-    if (file.options.style && !syntaxHighlightStyles[file.options.style]) {
-      fetchSyntaxHighlightStyle(file.options.style, file.path);
+    if (file.style && !syntaxHighlightStyles[file.style]) {
+      fetchSyntaxHighlightStyle(file.style, file.path);
       return renderComponent(Loading);
     }
 

--- a/src/components/VanillaTreeViewer/CodePanel/Code/Code.test.js
+++ b/src/components/VanillaTreeViewer/CodePanel/Code/Code.test.js
@@ -9,23 +9,21 @@ const namespace = 'app';
 
 beforeEach(() => {
   file = {
-    id: 'file+/alpha/beta/gamma.rb',
-    name: 'gamma.rb',
-    type: 'file',
-    path: '/alpha/beta/gamma.rb',
-    contents: `
-      def foo
-        true
-      end
-    `,
-    url: 'https://example.co/alpha/beta/gamma.rb',
-    error: null,
-    options: {
-      ...DEFAULT_OPTIONS,
-      ...{
-        style: 'custom-style',
-        language: 'ruby'
-      }
+    ...DEFAULT_OPTIONS,
+    ...{
+      id: 'file+/alpha/beta/gamma.rb',
+      name: 'gamma.rb',
+      type: 'file',
+      path: '/alpha/beta/gamma.rb',
+      contents: `
+        def foo
+          true
+        end
+      `,
+      url: 'https://example.co/alpha/beta/gamma.rb',
+      error: null,
+      language: 'ruby',
+      style: 'custom-style'
     }
   };
 
@@ -58,16 +56,16 @@ describe('<Code />', () => {
         expect(code.tabIndex).to.eql(-1);
         expect(code.innerHTML.trim()).to.eql(
           `
-        <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span></span>
-        <span class="hljs-literal">true</span>
-      <span class="hljs-keyword">end</span>
+          <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span></span>
+          <span class="hljs-literal">true</span>
+        <span class="hljs-keyword">end</span>
           `.trim()
         );
       });
 
       describe('no language is specified', () => {
         beforeEach(() => {
-          delete file.options.language;
+          delete file.language;
         });
 
         it('it renders the code without highlighting', () => {
@@ -77,9 +75,9 @@ describe('<Code />', () => {
           const code = pre.getElementsByTagName('code')[0];
           expect(code.innerHTML.trim()).to.eql(
             `
-      def foo
-        true
-      end
+        def foo
+          true
+        end
             `.trim()
           );
         });
@@ -98,7 +96,7 @@ describe('<Code />', () => {
 
       describe('no language is specified', () => {
         beforeEach(() => {
-          delete file.options.style;
+          delete file.style;
         });
 
         it('renders no styling', () => {

--- a/src/components/VanillaTreeViewer/CodePanel/CodePanel.test.js
+++ b/src/components/VanillaTreeViewer/CodePanel/CodePanel.test.js
@@ -9,23 +9,21 @@ const namespace = 'app';
 
 beforeEach(() => {
   file = {
-    id: 'file+/alpha/beta/gamma.rb',
-    name: 'gamma.rb',
-    type: 'file',
-    path: '/alpha/beta/gamma.rb',
-    contents: `
-      def foo
-        true
-      end
-    `,
-    url: 'https://example.co/alpha/beta/gamma.rb',
-    error: null,
-    options: {
-      ...DEFAULT_OPTIONS,
-      ...{
-        style: 'custom-style',
-        language: 'ruby'
-      }
+    ...DEFAULT_OPTIONS,
+    ...{
+      id: 'file+/alpha/beta/gamma.rb',
+      name: 'gamma.rb',
+      type: 'file',
+      path: '/alpha/beta/gamma.rb',
+      contents: `
+        def foo
+          true
+        end
+      `,
+      url: 'https://example.co/alpha/beta/gamma.rb',
+      error: null,
+      language: 'ruby',
+      style: 'custom-style'
     }
   };
 

--- a/src/components/VanillaTreeViewer/Tree/Builder/Builder.js
+++ b/src/components/VanillaTreeViewer/Tree/Builder/Builder.js
@@ -25,7 +25,8 @@ function newTreeNode(type, name, path, file) {
     treeNode.contents = file.contents || null;
     treeNode.url = file.url;
     treeNode.error = null;
-    treeNode.options = file.options;
+    treeNode.language = file.language;
+    treeNode.style = file.style;
   }
 
   return treeNode;
@@ -41,7 +42,7 @@ function normalizePath(path) {
   return newPath.toLowerCase();
 }
 
-function addToDirectoryTree(tree, file, globalOptions) {
+function addToDirectoryTree(tree, file) {
   /*
    * Parse each segment of the path, accounting for the 'root'
    * segment/directory as ''.
@@ -54,12 +55,8 @@ function addToDirectoryTree(tree, file, globalOptions) {
   let parentPath = null;
   let currentPath = '';
 
-  // Merge any relevant global options / defaults into the individual `file`
-  file.options = {
-    ...DEFAULT_OPTIONS,
-    ...(globalOptions || {}),
-    ...(file.options || {})
-  };
+  // Merge any defaults into the individual `file`
+  const fileWithDefaults = { ...DEFAULT_OPTIONS, ...file };
 
   segments.forEach((segment, idx) => {
     parentPath = currentPath;
@@ -83,19 +80,24 @@ function addToDirectoryTree(tree, file, globalOptions) {
      * Add a new node and add it to the parent (which is guranteed
      * to be a directory object with a `childPaths` key)
      */
-    tree[currentPath] = newTreeNode(type, segment, currentPath, file);
+    tree[currentPath] = newTreeNode(
+      type,
+      segment,
+      currentPath,
+      fileWithDefaults
+    );
     tree[parentPath].childPaths.push(currentPath);
   });
 
   return tree;
 }
 
-function toDirectoryTree(files, globalOptions) {
+function toDirectoryTree(files) {
   let tree = {};
   tree['/'] = newTreeNode('directory', '/', '/', null);
 
   files.forEach((file) => {
-    tree = addToDirectoryTree(tree, file, globalOptions);
+    tree = addToDirectoryTree(tree, file);
   });
 
   return tree;

--- a/src/components/VanillaTreeViewer/Validator/Validator.js
+++ b/src/components/VanillaTreeViewer/Validator/Validator.js
@@ -49,11 +49,7 @@ function allLanguagesValid(files) {
   const invalidLanguages = [];
 
   files.forEach((file) => {
-    if (!file.options) {
-      return;
-    }
-
-    const lang = file.options.language;
+    const lang = file.language;
 
     if (lang && HLJS_LANGUAGES.indexOf(lang) < 0) {
       invalidLanguages.push(lang);
@@ -68,11 +64,7 @@ function anyLanguagesUncommon(files) {
   const registeredLanguages = hljs.listLanguages();
 
   files.forEach((file) => {
-    if (!file.options) {
-      return;
-    }
-
-    const lang = file.options.language;
+    const lang = file.language;
 
     if (lang && registeredLanguages.indexOf(lang) < 0) {
       uncommonLanguages.push(lang);

--- a/src/components/VanillaTreeViewer/Validator/Validator.test.js
+++ b/src/components/VanillaTreeViewer/Validator/Validator.test.js
@@ -13,9 +13,7 @@ beforeEach(() => {
     {
       path: 'src/main.js',
       url: 'https://example.co/src/main.js',
-      options: {
-        language: 'javascript'
-      }
+      language: 'javascript'
     }
   ];
 });
@@ -131,7 +129,7 @@ describe('Validator.validateFiles', () => {
 
   describe('language is invalid', () => {
     beforeEach(() => {
-      files[1].options.language = 'foo';
+      files[1].language = 'foo';
     });
 
     it('marks the files as invalid', testForInvalid);
@@ -139,7 +137,7 @@ describe('Validator.validateFiles', () => {
 
   describe('language is valid, but uncommon', () => {
     beforeEach(() => {
-      files[1].options.language = 'actionscript';
+      files[1].language = 'actionscript';
     });
 
     it('marks the files as invalid', testForInvalid);

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.js
@@ -13,7 +13,7 @@ import Store from 'lib/Store/Store';
 import { validateFiles } from './Validator/Validator';
 
 class VanillaTreeViewer extends Component {
-  constructor(id, files, options) {
+  constructor(id, files) {
     super({
       store: new Store({}),
       element: document.getElementById(id)
@@ -35,7 +35,7 @@ class VanillaTreeViewer extends Component {
 
     if (validationResult.isValid) {
       selectedPath = normalizePath(defaultSelectedPath(files));
-      tree = toDirectoryTree(files, options);
+      tree = toDirectoryTree(files);
     }
 
     this.store.state = {

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
@@ -5,7 +5,7 @@ import fetchMock from 'fetch-mock';
 import { hljsStyleUrl } from 'components/VanillaTreeViewer/hljs';
 import VanillaTreeViewer from 'components/VanillaTreeViewer/VanillaTreeViewer';
 
-let files, options;
+let files;
 
 fetchMock.config.overwriteRoutes = true;
 
@@ -23,8 +23,6 @@ beforeEach(() => {
       url: 'https://example.co/path/to/epsilon.js'
     }
   ];
-
-  options = {};
 
   // Set up DOM to mount component
   document.body.innerHTML = `<div id='${id}'></div>`;
@@ -124,38 +122,18 @@ describe('<VanillaTreeViewer />', () => {
       );
     });
 
-    it('overrides styling for all files with the global options', async () => {
-      options.style = 'my-global-style';
-      fetchMock.get(
-        hljsStyleUrl('my-global-style'),
-        '.hljs{display:inline-block;}'
-      );
+    describe('a style is specified for a file', () => {
+      it('renders the specified style', async () => {
+        files[0].style = 'my-file-style';
+        fetchMock.get(hljsStyleUrl('my-file-style'), '.hljs{display:flex;}');
 
-      render();
-      await waitUntil(hasRenderedCode);
+        render();
+        await waitUntil(hasRenderedCode);
 
-      const code = rendered().getElementsByClassName('vtv__code')[0];
-      const style = code.getElementsByTagName('style')[0];
-      expect(style.innerHTML).to.equal(`#${id} .hljs{display:inline-block;}`);
-    });
-
-    it('overrides styling for specific files with the file-level options', async () => {
-      options.style = 'my-global-style';
-      fetchMock.get(
-        hljsStyleUrl('my-global-style'),
-        '.hljs{display:inline-block;}'
-      );
-
-      files[0].options = {};
-      files[0].options.style = 'my-file-style';
-      fetchMock.get(hljsStyleUrl('my-file-style'), '.hljs{display:flex;}');
-
-      render();
-      await waitUntil(hasRenderedCode);
-
-      const code = rendered().getElementsByClassName('vtv__code')[0];
-      const style = code.getElementsByTagName('style')[0];
-      expect(style.innerHTML).to.equal(`#${id} .hljs{display:flex;}`);
+        const code = rendered().getElementsByClassName('vtv__code')[0];
+        const style = code.getElementsByTagName('style')[0];
+        expect(style.innerHTML).to.equal(`#${id} .hljs{display:flex;}`);
+      });
     });
   });
 
@@ -169,36 +147,19 @@ describe('<VanillaTreeViewer />', () => {
       expect(codeTag.innerHTML).to.equal('def foo;true;end');
     });
 
-    it('overrides highlighting for all files with the global options', async () => {
-      options.language = 'ruby';
+    describe('a syntax highlighting language is specified for a file', () => {
+      it('highlights the specified file', async () => {
+        files[0].language = 'javascript';
 
-      render();
-      await waitUntil(hasRenderedCode);
+        render();
+        await waitUntil(hasRenderedCode);
 
-      const code = rendered().getElementsByClassName('vtv__code')[0];
-      const codeTag = code.getElementsByTagName('code')[0];
-      expect(codeTag.innerHTML).to.equal(
-        '<span class="hljs-function">' +
-          '<span class="hljs-keyword">def</span> ' +
-          '<span class="hljs-title">foo</span>;</span>' +
-          '<span class="hljs-literal">true</span>;' +
-          '<span class="hljs-keyword">end</span>'
-      );
-    });
-
-    it('overrides highlighting for specific files with the file-level options', async () => {
-      options.language = 'ruby';
-      files[0].options = {};
-      files[0].options.language = 'javascript';
-
-      render();
-      await waitUntil(hasRenderedCode);
-
-      const code = rendered().getElementsByClassName('vtv__code')[0];
-      const codeTag = code.getElementsByTagName('code')[0];
-      expect(codeTag.innerHTML).to.equal(
-        'def foo;<span class="hljs-literal">true</span>;end'
-      );
+        const code = rendered().getElementsByClassName('vtv__code')[0];
+        const codeTag = code.getElementsByTagName('code')[0];
+        expect(codeTag.innerHTML).to.equal(
+          'def foo;<span class="hljs-literal">true</span>;end'
+        );
+      });
     });
   });
 
@@ -378,8 +339,7 @@ describe('<VanillaTreeViewer />', () => {
       });
 
       it("renders an error when the second file's styles dont fetch", async () => {
-        files[1].options = {};
-        files[1].options.style = 'bad-style';
+        files[1].style = 'bad-style';
         fetchMock.get(hljsStyleUrl('bad-style'), {
           throws: new TypeError('Some error')
         });
@@ -513,7 +473,7 @@ const waitUntil = (condition) => {
 };
 
 const render = () => {
-  const viewer = new VanillaTreeViewer(id, files, options);
+  const viewer = new VanillaTreeViewer(id, files);
   viewer.render();
 
   return rendered();


### PR DESCRIPTION
`VanillaTreeViewer` currently supports specifying 3 levels of options:

  * file level options
  * global (shared) options
  * default options

There's a few issues with this:

  1. It's confusing, and overly complicated. Tracking separate sets of
     options and implementing fallback logic is difficult

  2. It's misleading - "global" options are really options shared across
     a single `VanillaTreeViewer` instance

  3. In general, we want to set ourselves up to move to an entirely new
     API (outside the scope of this change). Updating this makes that
     upcoming transition easier.

This change removes the ability to specify a separate of "global" options.
Because it updates the public facing constructor signature, this is a
*breaking change* (backwards incompatible).

```javascript
new VanillaTreeViewer(id, files, options).render();   # OLD
new VanillaTreeViewer(id, files).render();            # NEW
```

Internally, this also flattens the options structure so that we can track
all options in a single object, instead of a separate nested object for
"options":

Old:

```
{
  path: ...,
  url: ...
  options: {
    language: ...,
    ...
  }
}
```

New:

```
{
  path: ...,
  url: ...
  language: ...,
  ...
}
```

The scope of this commit is:

  * Removing the standalone `options` argument from the public API
  * Flattening the internal object we use to track options
  * Updating tests
  * Updating the demo page
  * README documentation updates