### PR TITLE
Parse structure and options from the DOM directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,6 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
 
 <img src="meta/demo.png" />
 
-
-### Benefits
-
-* Lightweight
-  * built with pure JavaScript
-  * only 1 dependency! `VanillaTreeViewer` uses the wonderful [highlight.js](https://highlightjs.org/) library for syntax highlighting
-* Mobile-friendly
-* Easily customize-able syntax highlighting and component styling
-* Well tested
-
 # Table of Contents
 
 - [Quick Start](#quick-start)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Show off multiple files or code snippets in an elegant and space saving way.
 
 Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-rails-without-the-react-rails-gem)), tutorials, documentation, etc...
 
-* [view a live demo](https://abhchand.me/vanilla-tree-viewer)
+* [view a **live demo**](https://abhchand.me/vanilla-tree-viewer)
 * [view this project on npm](https://www.npmjs.com/package/vanilla-tree-viewer)
 
 <img src="meta/demo.png" />
@@ -32,13 +32,10 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
 # Table of Contents
 
 - [Quick Start](#quick-start)
-  - [`<script>` tag placement](#script-tag-placement)
 - [Syntax Highlighting](#syntax-highlighting)
   - [Default Language Support](#default-language-support)
   - [Highlighting Other Languages](#highlighting-other-languages)
-- [Configuration](#configuration)
-  - [`id`](#config-id)
-  - [`files`](#config-files)
+- [Options](#options)
 - [Customization](#customization)
   - [Configuring Width and Alignment](#configuring-width-and-alignment)
   - [Customizing Styling](#customizing-styling)
@@ -58,46 +55,41 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
 </head>
 ```
 
-② Define one or more DOM nodes (with unique `id`s) on which to render a new viewer.
+② For each `VanillaTreeViewer` instance you'd like to create, define the list of files to be displayed as an HTML `list`. You **must** include the `.vtv` class.
+
+(See [Options](#options) for a full list of `data-*` attribute options.)
 
 ```html
-<div id='my-viewer'></div>
+<ol class='vtv' data-language="javascript">
+
+  <!-- File 1 -->
+  <!-- Display the contents under the path `src/index.js` -->
+  <li data-path="src/index.js" >
+import Foo from './foo';
+export { Foo.bar }
+  </li>
+
+  <!-- File 2 -->
+  <!-- Fetch file contents from a `url` instead -->
+  <!-- Override syntax highlighting (`data-language`) for this file -->
+  <li
+    data-path="package.json"
+    data-url="https://raw.githubusercontent.com/axios/axios/master/package.json"
+    data-language="json">
+  </li>
+</ol>
 ```
 
-③ At the bottom of your page, include a `<script>` tag that defines the list of files and initializes the viewer.
+③ Finally, call `VanillaTreeViewer.renderAll()` after page load.
+
+This will find and parse all `.vtv` elements and render a `VanillaTreeViewer` component at that location.
 
 ```html
 <script>
-  const files = [
-    {
-      path: 'lib/axios.js',
-      url: 'https://raw.githubusercontent.com/axios/axios/master/lib/axios.js',
-      language: 'json'
-    },
-    {
-      path: 'package.json',
-      // Specify the file contents directly, instead of a URL
-      contents: '{ \"foo\": \"bar\" }',
-      language: 'json'
-    }
-  ];
-
-  new VanillaTreeViewer('my-viewer', files).render();
+  document.addEventListener('DOMContentLoaded', function() {
+    VanillaTreeViewer.renderAll();
+  }, false);
 </script>
-```
-
-For a fully functioning copy-pastable example that you can also run locally, see [`examples/simple.html`](https://github.com/abhchand/vanilla-tree-viewer/blob/master/examples/simple.html)
-
-### <a name="script-tag-placement"></a>`<script>` tag placement
-
-In the above code snippet we placed our `<script>` tag at the end so the script runs _after_ our DOM node `#my-viewer` has rendered.
-
-Alternately you can place the `<script>` tag at the top and have it wait till the DOM content is loaded:
-
-```js
-document.addEventListener('DOMContentLoaded', function() {
-  // Include script content from above here
-}, false);
 ```
 
 # <a name="syntax-highlighting"></a>Syntax Highlighting
@@ -128,67 +120,55 @@ For example, highlighting `ActionScript`:
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.1/languages/actionscript.min.js"></script>
 ```
 
-# <a name="configuration"></a>Configuration
+# <a name="options"></a>Options
 
-```js
-var viewer = new VanillaTreeViewer(id, files);
-viewer.render();
+`VanillaTreeViewer` uses HTML attributes on the parent and child nodes to configure behavior
+
+```html
+<!-- Parent node -->
+<ol class="vtv">
+  <!-- Child node -->
+  <li data-path="src/index.js">
+    <!-- File contents -->
+  </li>
+</ol>
 ```
 
-### <a name="config-id"></a>`id`
+The following attribute options are available:
 
-A `String` representing the HTML `id` of the DOM node the viewer will be rendered under.
-
-You can render multiple instances of the viewer, but keep in mind -
-
-* Each instance needs to have a unique HTML `id`
-* You'll need to instantiate a new `VanillaTreeViewer` object and call `render()` for each instance of the viewer
-
-### <a name="config-files"></a>`files`
-
-`VanillaTreeViewer` expects an **array of objects** (`files = [{}, {}, ...]`) defining the list of files to display.
-
-Each file object can have the following keys:
-
-| Key  | Type | Required? | Default | Description
-| ------------- | ------------- | ------------- | ------------- | ------------- |
-| `path`  | `String` | Yes | n/a | The path under which the file should be displayed in the viewer tree |
-| `url`  | `String` | One of `url`/`contents` required | `null` | The URL to fetch the file contents from (e.g. Github Raw URLs). A simple GET request is performed to fetch file contents. |
-| `contents` | `String` | One of `url`/`contents` required | `null` | The file contents to be displayed. Takes precedence over `url` if both are set. |
-| `selected` | `Boolean` | No | `false` | Indicates whether this file should be selected when the viewer loads. If more than one file is marked `selected: true`, the first one is chosen. Similarly, if no file is marked `selected: true`, the first file in the list will be selected by default.
-| `language` | `String` | No | `null` | The `highlight.js` language to use for syntax highlighting. [See a full list of supported languages](https://github.com/highlightjs/highlight.js/tree/master/src/languages).
-| `style` | `String` | No | `'monokai-sublime'` | The `highlight.js` style (color theme) to use for syntax highlighting. [See a full list of supported styles](https://github.com/highlightjs/highlight.js/tree/master/src/styles).
-
-**NOTE**: The [`highlight.js` demo page](https://highlightjs.org/static/demo/) will let you preview various languages and styles.
+| Attribute  | Type | Applies to | Required? | Default | Description
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| `id` | `String` | parent node only | No | auto-generated | Each `VanillaTreeViewer` instance is automatically assigned a unique, sequential `id` (`vtv--1`, `vtv--2`, etc...). However, if you explicitly specify an `id` it will be preserved and used instead of the auto-generated value.
+| `class` | `String` | parent node only | **Yes** | n/a | The class name `.vtv` **must** exist on each parent node. Optionally, if you specify any other custom classes they will also be preserved.
+| `data-path`  | `String` | child node only | **Yes** | n/a | The path under which the file should be displayed in the viewer tree |
+| `data-url`  | `String` | child node only | Yes (if no inline file contents specified) | `null` | The URL to fetch the file contents from (e.g. Github Raw URLs). Any inline file contents in the HTML always take precedence over `data-url`.|
+| `data-selected` | `Boolean` | child node only | No | `false` | Indicates whether this file should be selected when the viewer loads. If more than one file is marked `data-selected=true`, the first one is chosen. Similarly, if no file is marked `data-selected=true`, the first file in the list will be selected by default.
+| `data-language` | `String` | child or parent node | No | `null` | The `highlight.js` language to use for syntax highlighting. [See a full list of supported languages](https://github.com/highlightjs/highlight.js/tree/master/src/languages).
+| `data-style` | `String` | child or parent node | No | `'monokai-sublime'` | The `highlight.js` style (color theme) to use for syntax highlighting. [See a full list of supported styles](https://github.com/highlightjs/highlight.js/tree/master/src/styles). (**NOTE**: The [`highlight.js` demo page](https://highlightjs.org/static/demo/) will let you preview various languages and styles.)
 
 
 # <a name="customization"></a>Customization
 
 ### <a name="configuring-width-and-alignment"></a>Configuring Width and Alignment
 
-By default `VanillaTreeViewer` takes the full width of the DOM container element it's mounted on to. It is recommended that you style this DOM element accordingly to set the desired width and alignment.
+All `VanillaTreeViewer` instances are wrapped in a containing `<div>` with a `.vtv-wrapper` class. It is recommended that you style this wrapper element accordingly to set the desired width and alignment.
 
-Here is one approach that handles styling for all mount nodes:
+For example:
 
 ```html
-<head>
-  <style>
-    .vtv-mount-node {
-      margin: auto;
-      max-width: 980px;
-    }
-  </style>
-</head>
-<body>
-  <div id='my-viewer' class='vtv-mount-node'></div>
-</body>
+<style>
+  .vtv-wrapper {
+    margin: auto;
+    max-width: 980px;
+  }
+</style>
 ```
 
 ### <a name="customizing-styling"></a>Customizing Styling
 
 The default styling for `VanillaTreeViewer` is based off the look and feel of [Sublime Text](https://www.sublimetext.com/).
 
-`VanillaTreeViewer` does not provide a programmatic way to customize the component itself, however you  are free to customize the look and feel as needed by overriding [the CSS](https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@1.1.1/dist/main.min.css) for the `VanillaTreeViewer` component.
+While you can change the `style`/theme for any specific file(s), `VanillaTreeViewer` does not provide a programmatic way to customize the component itself. However, you are free to customize the look and feel as needed by overriding [the CSS](https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@1.1.1/dist/main.min.css) at your discretion.
 
 * All top-level CSS classes begin with `.vtv*`
 * Please be aware that the default styling utilizes [media queries](https://www.w3schools.com/css/css_rwd_mediaqueries.asp) to apply styling at different screen widths.
@@ -218,7 +198,7 @@ This will open `http://localhost:3035` in a browser window. Any changes made to 
 
 - If you have an issue or feature request, please [open an issue here](https://github.com/abhchand/vanilla-tree-viewer/issues/new).
 
-- Contribution is encouraged! But please open an issue first to suggest a new feature and confirm that it will be accepted before filing a pull request.
+- Contribution is encouraged! But please open an issue first to suggest a new feature and confirm that it will be accepted before creating a pull request.
 
 You can also help support this project. If you've found this or any other of my projects useful, I would greatly appreciate if you could [buy me a coffee](https://www.buymeacoffee.com/abhchand)!
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,22 +1,5 @@
 import VanillaTreeViewer from '../src/components/VanillaTreeViewer/VanillaTreeViewer';
 
-const files = [
-  {
-    path: 'lib/core/transformData.js',
-    url: 'https://raw.githubusercontent.com/axios/axios/master/lib/core/transformData.js',
-    language: 'javascript'
-  },
-  {
-    path: 'lib/axios.js',
-    url: 'https://raw.githubusercontent.com/axios/axios/master/lib/axios.js',
-    language: 'javascript'
-  },
-  {
-    path: 'package.json',
-    url: 'https://raw.githubusercontent.com/axios/axios/master/package.json',
-    language: 'json'
-  }
-];
-
-let viewer = new VanillaTreeViewer('app', files);
-viewer.render();
+document.addEventListener('DOMContentLoaded', function() {
+  VanillaTreeViewer.renderAll();
+}, false);

--- a/demo/template.html
+++ b/demo/template.html
@@ -7,7 +7,7 @@
     <style>
       body { font-family: 'Helvetica' }
 
-      #app {
+      .vtv-wrapper {
         margin: auto;
         max-width: 980px;
       }
@@ -70,7 +70,12 @@
       Below is a demo displaying a few sample files from the <a href='https://github.com/axios/axios' target='_blank'>axios.js</a> project
     </p>
 
-    <div id='app'></div>
+    <ol class='vtv' data-language="javascript">
+      <li data-path="lib/axios.js" data-url="https://raw.githubusercontent.com/axios/axios/master/lib/axios.js">
+      </li>
+      <li data-path="package.json" data-url="https://raw.githubusercontent.com/axios/axios/master/package.json" data-language="json" data-selected=true>
+      </li>
+    </ol>
 
     <p style="text-align: center;margin-top: 45px;">
        If you've found this or any other of my projects useful, I would greatly appreciate if you could <a href='https://www.buymeacoffee.com/abhchand' target='_blank'>buy me a coffee</a> ☕!

--- a/src/components/VanillaTreeViewer/Parser/Parser.js
+++ b/src/components/VanillaTreeViewer/Parser/Parser.js
@@ -1,0 +1,172 @@
+/*
+ * Removes any `null` or `undefined`
+ * keys from an object
+ */
+const removeBlanks = (obj) => {
+  Object.keys(obj).forEach((key) => {
+    /*
+     * Use `==` explicitly to catch both `null` and
+     * `undefined`
+     */
+    // eslint-disable-next-line no-eq-null
+    if (obj[key] == null || obj[key] === '') {
+      delete obj[key];
+    }
+  });
+
+  return obj;
+};
+
+const replaceUserNodeInDOM = (userNode, nodeIdx) => {
+  // Preserve `id` if it exists, if not generate a new value
+  const id = userNode.id || `vtv--${nodeIdx + 1}`;
+
+  // Add `.vtv-wrapper` to indicate this node has been parsed.
+  userNode.classList.add('vtv-wrapper');
+
+  // Create mount point
+  const mountNode = document.createElement('div');
+  mountNode.id = id;
+  mountNode.classList = userNode.classList;
+
+  // Replace user node with new node
+  userNode.parentNode.replaceChild(mountNode, userNode);
+
+  return id;
+};
+
+/*
+ * Parses user-defined nodes in the DOM on which `VanillaTreeViewer`
+ * instances will be mounted.
+ *
+ * Specifically, this does 2 things:
+ *
+ *  1. Parses options from each user-defined node
+ *  2. Replaces each user-defined node with a generic mount node
+ *
+ *
+ * Users specify optionurations using inline HTML and `data-*`
+ * attributes, all of which will be parsed here and removed. The full list
+ * of attributes a user may specify can be found in the `README`.
+ *
+ * Users *must* specify the `.vtv` class on each node, since this is how
+ * `VanillaTreeViewer` know whether to parse that node.
+ *
+ * Each mount node will be assigned a sequential `id` for uniqueness. However
+ * if the user already specified an `id`, it will be used instead.
+ *
+ * Each mount node will be assigned a class of `.vtv-wrapper` to mark this node
+ * as parsed. Any custom classes defined on the node will still be preserved.
+ *
+ * This function does *not* perform any validation. This is performed
+ * later when initializing and mounting the `VanillaTreeViewer` object
+ *
+ * # Example
+ *
+ * Imagine a DOM with a single parent node containing 2 file nodes:
+ *
+ *     <ol data-language="ruby" class="vtv foo">
+ *
+ *       <!-- FILE 1 -->
+ *       <li
+ *         data-path="app/models/company.rb"
+ *         data-url="https://example.com/path/to/company.rb">
+ *       </li>
+ *
+ *       <!-- FILE 2 -->
+ *       <li
+ *         data-path="app/javascript/index.js"
+ *         data-selected=true
+ *         data-language="javascript">
+ *         var foo = 'bar';
+ *
+ *         export { foo };
+ *       </li>
+ *     </ol>
+ *
+ * When parsing the above DOM, this function will return:
+ *
+ *     [
+ *       [
+ *         'vtv--1',
+ *         [
+ *           {
+ *             path: 'app/models/company.rb',
+ *             url: 'https://example.com/path/to/company.rb',
+ *             language: 'ruby'
+ *           },
+ *           {
+ *             path: 'app/javascript/index.js',
+ *             contents: 'var foo = .... { foo };',
+ *             selected: true,
+ *             language: 'javascript'
+ *           }
+ *         ]
+ *       ]
+ *     ]
+ *
+ * Additionally, the user defined node will be entirely replaced with
+ * the following mount node:
+ *
+ *     <div id='vtv--1' class="vtv foo vtv-wrapper"></div>
+ */
+const parseUserNodes = () => {
+  const nodes = [];
+
+  document.querySelectorAll('.vtv').forEach((userNode, userNodeIdx) => {
+    /*
+     * Sanity check: If the node has a `vtv-wrapper` class, we've already
+     * parsed this node and we can safely ignore this node.
+     */
+    if (userNode.classList.contains('vtv-wrapper')) {
+      return;
+    }
+
+    const files = [];
+
+    /*
+     * Common options defined on the parent node. Will be applied as fallbacks
+     * to each individual file node
+     */
+    const sharedOptions = removeBlanks({
+      language: userNode.dataset.language,
+      style: userNode.dataset.style
+    });
+
+    // Find every file node under the user node
+    userNode.querySelectorAll('li').forEach((fileNode) => {
+      /*
+       * We only want to consider direct children. Ideally we'd use
+       * something like `querySelectorAll('> li')` for this, but that's
+       * not supported.
+       */
+      if (fileNode.parentNode !== userNode) {
+        return;
+      }
+
+      files.push(
+        removeBlanks({
+          path: fileNode.dataset.path,
+          url: fileNode.dataset.url,
+          contents: fileNode.innerHTML.trim(),
+          selected:
+            typeof fileNode.dataset.selected === 'string' &&
+            fileNode.dataset.selected.toLowerCase() === 'true'
+              ? true
+              : null,
+          language: fileNode.dataset.language || sharedOptions.language,
+          style: fileNode.dataset.style || sharedOptions.style
+        })
+      );
+    });
+
+    // Create a new mount node to replace the existing user node
+    const mountId = replaceUserNodeInDOM(userNode, userNodeIdx);
+
+    nodes.push([mountId, files]);
+  });
+
+  return nodes;
+};
+
+export { parseUserNodes };

--- a/src/components/VanillaTreeViewer/Parser/Parser.test.js
+++ b/src/components/VanillaTreeViewer/Parser/Parser.test.js
@@ -1,0 +1,414 @@
+import { expect } from 'chai';
+import { parseUserNodes } from './Parser';
+
+describe('Parser.parseUserNodes', () => {
+  describe('mount id', () => {
+    it('generates a mount id for each parent node', () => {
+      document.body.innerHTML = `
+        <ol class='vtv'><li></li></ol>
+        <ol class='vtv'><li></li></ol>
+        `;
+
+      const result = parseUserNodes();
+      expect(result.length).to.equal(2);
+
+      let mountId = result[0][0];
+      expect(mountId).to.eql('vtv--1');
+
+      mountId = result[1][0];
+      expect(mountId).to.eql('vtv--2');
+    });
+
+    describe('parent node already has an `id`', () => {
+      it('preserves the `id` for the parent node', () => {
+        document.body.innerHTML = `
+          <ol id='foo' class='vtv'><li></li></ol>
+          <ol class='vtv'><li></li></ol>
+          `;
+
+        const result = parseUserNodes();
+        expect(result.length).to.equal(2);
+
+        let mountId = result[0][0];
+        expect(mountId).to.eql('foo');
+
+        mountId = result[1][0];
+        expect(mountId).to.eql('vtv--2');
+      });
+    });
+
+    describe('parent node has a `.vtv-wrapper` class', () => {
+      it('does not process the user node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv vtv-wrapper'><li></li></ol>
+          <ol class='vtv'><li></li></ol>
+          `;
+
+        const result = parseUserNodes();
+        expect(result.length).to.equal(1);
+
+        /*
+         * Even though the first node is skipped, the index/counter
+         * is still preserved so the `id` is generated with `2`
+         */
+        const mountId = result[0][0];
+        expect(mountId).to.eql('vtv--2');
+      });
+    });
+  });
+
+  describe('file options', () => {
+    describe('parsing the `path` option', () => {
+      it('parses the option from the file node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li data-path="alpha/beta.js"></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        expect(result.length).to.equal(1);
+
+        const files = result[0][1];
+
+        expect(files).to.deep.equal([{ path: 'alpha/beta.js' }]);
+      });
+    });
+
+    describe('parsing the `url` option', () => {
+      it('parses the option from the file node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li data-url="https://example.co/path/to/beta.js"></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([
+          { url: 'https://example.co/path/to/beta.js' }
+        ]);
+      });
+    });
+
+    describe('parsing the `contents` option', () => {
+      it('parses the option from the file node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li>function foo() { return bar(); }</li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([
+          { contents: 'function foo() { return bar(); }' }
+        ]);
+      });
+
+      it('trims the content', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li>
+
+            function foo() { return bar(); }
+            </li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([
+          { contents: 'function foo() { return bar(); }' }
+        ]);
+      });
+
+      it('handles newlines', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li>
+              function foo() {
+                return bar();
+              }
+            </li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([
+          {
+            contents:
+              'function foo() {\n                return bar();\n              }'
+          }
+        ]);
+      });
+    });
+
+    describe('parsing the `selected` option', () => {
+      it('parses the option from the file node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li data-selected=true></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ selected: true }]);
+      });
+
+      it('handles string values', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li data-selected="true"></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ selected: true }]);
+      });
+
+      it('is case insensitive', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li data-selected=TrUe></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ selected: true }]);
+      });
+
+      it('defaults to `null` for anything else', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'>
+            <li data-selected=false></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        /*
+         * `null`/blank values are removed from the option
+         * automatically, resulting in an empty object
+         */
+        expect(files).to.deep.equal([{}]);
+      });
+    });
+
+    describe('parsing the `language` option', () => {
+      it('parses the option from the parent node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv' data-language="java">
+            <li></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ language: 'java' }]);
+      });
+
+      it('overrides with any value set on the file node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv' data-language="java">
+            <li data-language="javascript"></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ language: 'javascript' }]);
+      });
+    });
+
+    describe('parsing the `style` option', () => {
+      it('parses the option from the parent node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv' data-style="monokai">
+            <li></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ style: 'monokai' }]);
+      });
+
+      it('overrides with any value set on the file node', () => {
+        document.body.innerHTML = `
+          <ol class='vtv' data-style="monokai">
+            <li data-style="yuri"></li>
+          </ol>
+          `;
+
+        const result = parseUserNodes();
+        const files = result[0][1];
+
+        expect(result.length).to.equal(1);
+        expect(files).to.deep.equal([{ style: 'yuri' }]);
+      });
+    });
+
+    it('correctly parses multiple parent nodes', () => {
+      document.body.innerHTML = `
+        <ol class='vtv'>
+          <li data-path="alpha/beta.js"></li>
+        </ol>
+
+        <ol class='vtv'>
+          <li data-path="gamma/delta.js"></li>
+        </ol>
+        `;
+
+      const result = parseUserNodes();
+      expect(result.length).to.equal(2);
+
+      let files = result[0][1];
+
+      expect(files).to.deep.equal([{ path: 'alpha/beta.js' }]);
+
+      files = result[1][1];
+
+      expect(files).to.deep.equal([{ path: 'gamma/delta.js' }]);
+    });
+
+    it('correctly parses multiple file nodes', () => {
+      document.body.innerHTML = `
+        <ol class='vtv'>
+          <li data-path="alpha/beta.js"></li>
+          <li data-path="gamma/delta.js"></li>
+        </ol>
+        `;
+
+      const result = parseUserNodes();
+      const files = result[0][1];
+
+      expect(result.length).to.equal(1);
+      expect(files).to.deep.equal([
+        { path: 'alpha/beta.js' },
+        { path: 'gamma/delta.js' }
+      ]);
+    });
+
+    it('only parses file nodes which are direct children of the parent node', () => {
+      document.body.innerHTML = `
+        <ol class='vtv'>
+          <li data-path="alpha/beta.js"></li>
+          <div>
+            <li data-path="gamma/delta.js"></li>
+          </div>
+        </ol>
+        `;
+
+      const result = parseUserNodes();
+      const files = result[0][1];
+
+      expect(result.length).to.equal(1);
+      expect(files).to.deep.equal([{ path: 'alpha/beta.js' }]);
+    });
+
+    it('ignores parent nodes that already have the `.vtv-wrapper` class', () => {
+      document.body.innerHTML = `
+        <ol class='vtv vtv-wrapper'>
+          <li data-path="alpha/beta.js"></li>
+        </ol>
+        `;
+
+      const result = parseUserNodes();
+      expect(result.length).to.equal(0);
+    });
+  });
+
+  describe('replacing user node with a mount node', () => {
+    it('replaces the user nodes with a mount nodes', () => {
+      document.body.innerHTML = `
+        <ol class='vtv'><li></li></ol>
+        <ol class='vtv'><li></li></ol>
+        `.trim();
+
+      parseUserNodes();
+
+      expect(document.body.innerHTML).to.eql(
+        `
+        <div id="vtv--1" class="vtv vtv-wrapper"></div>
+        <div id="vtv--2" class="vtv vtv-wrapper"></div>
+        `.trim()
+      );
+    });
+
+    describe('user node already has an `id` specified', () => {
+      it('preserves the original `id` value', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'><li></li></ol>
+          <ol id='foo' class='vtv'><li></li></ol>
+          `.trim();
+
+        parseUserNodes();
+
+        expect(document.body.innerHTML).to.eql(
+          `
+          <div id="vtv--1" class="vtv vtv-wrapper"></div>
+          <div id="foo" class="vtv vtv-wrapper"></div>
+          `.trim()
+        );
+      });
+    });
+
+    describe('user node has a `.vtv-wrapper` class set', () => {
+      it('does not process the user node', () => {
+        document.body.innerHTML =
+          `<ol class="vtv vtv-wrapper"><li></li></ol>`.trim();
+
+        parseUserNodes();
+
+        expect(document.body.innerHTML).to.eql(
+          `<ol class="vtv vtv-wrapper"><li></li></ol>`.trim()
+        );
+      });
+    });
+
+    describe('user node has other classes set', () => {
+      it('preserves the original class list', () => {
+        document.body.innerHTML = `
+          <ol class='vtv'><li></li></ol>
+          <ol class='vtv foo bar'><li></li></ol>
+          `.trim();
+
+        parseUserNodes();
+
+        expect(document.body.innerHTML).to.eql(
+          `
+          <div id="vtv--1" class="vtv vtv-wrapper"></div>
+          <div id="vtv--2" class="vtv foo bar vtv-wrapper"></div>
+          `.trim()
+        );
+      });
+    });
+  });
+});

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.js
@@ -7,12 +7,21 @@ import { normalizePath, toDirectoryTree } from './Tree/Builder/Builder';
 import Component from 'lib/Component';
 import defaultSelectedPath from './Helpers/defaultSelectedPath';
 import { hljsStyleUrl } from './hljs';
+import { parseUserNodes } from './Parser/Parser';
 import { renderComponent } from './Helpers/renderComponent';
 import setTreeNodeToFullWidth from './Helpers/setTreeNodeToFullWidth';
 import Store from 'lib/Store/Store';
 import { validateFiles } from './Validator/Validator';
 
 class VanillaTreeViewer extends Component {
+  static renderAll() {
+    /*
+     * Extract configuration from each user-defined node
+     * and render a `VanillaTreeViewer` instance on that node
+     */
+    parseUserNodes().forEach((args) => new VanillaTreeViewer(...args).render());
+  }
+
   constructor(id, files) {
     super({
       store: new Store({}),

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.js
@@ -121,7 +121,7 @@ class VanillaTreeViewer extends Component {
     /*
      * Creates HTMLElement:
      *
-     * <div class='vtv'>
+     * <div class='vtv-root'>
      *   {Tree}
      *   {CodePanel}
      * </div>
@@ -129,7 +129,7 @@ class VanillaTreeViewer extends Component {
      */
 
     const div = document.createElement('div');
-    div.classList.add('vtv');
+    div.classList.add('vtv-root');
 
     const treeEl = renderComponent(Tree, {
       tree: tree,

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.scss
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.scss
@@ -1,7 +1,7 @@
 @import "components/VanillaTreeViewer/Breakpoints.scss";
 @import "components/VanillaTreeViewer/Colors.scss";
 
-.vtv {
+.vtv-root {
   display: flex;
   flex-flow: column nowrap;
   align-items: stretch;

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.scss
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.scss
@@ -1,6 +1,9 @@
 @import "components/VanillaTreeViewer/Breakpoints.scss";
 @import "components/VanillaTreeViewer/Colors.scss";
 
+.vtv-wrapper {
+}
+
 .vtv-root {
   display: flex;
   flex-flow: column nowrap;

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
@@ -49,7 +49,7 @@ describe('<VanillaTreeViewer />', () => {
     render();
     await waitUntil(hasRenderedCode);
 
-    expect(rendered().classList.contains('vtv')).to.be.true;
+    expect(rendered().classList.contains('vtv-root')).to.be.true;
   });
 
   it('renders the path', async () => {


### PR DESCRIPTION

- [x] [Breaking Change] Parse structure and options from the DOM directly
- [x] Remove `Benefits` section
- [x] Use `.vtv-root` instead of `.vtv` for the top level CSS class name