### PR TITLE
Update `path` validation

### DIFF
--- a/src/components/VanillaTreeViewer/Tree/Builder/Builder.js
+++ b/src/components/VanillaTreeViewer/Tree/Builder/Builder.js
@@ -39,7 +39,7 @@ function normalizePath(path) {
     newPath = `/${newPath}`;
   }
 
-  return newPath.toLowerCase();
+  return newPath;
 }
 
 function addToDirectoryTree(tree, file) {

--- a/src/components/VanillaTreeViewer/Tree/Builder/Builder.test.js
+++ b/src/components/VanillaTreeViewer/Tree/Builder/Builder.test.js
@@ -97,14 +97,14 @@ describe('Builder.toDirectoryTree', () => {
   });
 
   describe('parsing paths', () => {
-    it('handles paths case insensitively', () => {
+    it('preserves the original path case', () => {
       files[0].path = 'AlPhA/BeTA/gaMMa.rb';
 
       const tree = toDirectoryTree(files);
-      const node = tree['/alpha/beta/gamma.rb'];
+      const node = tree['/AlPhA/BeTA/gaMMa.rb'];
 
-      expect(node.name).to.equal('gamma.rb');
-      expect(node.path).to.equal('/alpha/beta/gamma.rb');
+      expect(node.name).to.equal('gaMMa.rb');
+      expect(node.path).to.equal('/AlPhA/BeTA/gaMMa.rb');
     });
 
     it("handles paths prefixed with '/'", () => {
@@ -284,7 +284,7 @@ describe('Builder.normalizePath', () => {
     expect(normalizePath('foo')).to.equal('/foo');
   });
 
-  it('downcases the path', () => {
-    expect(normalizePath('/FoO')).to.equal('/foo');
+  it('preserves the path case', () => {
+    expect(normalizePath('/FoO')).to.equal('/FoO');
   });
 });

--- a/src/components/VanillaTreeViewer/Validator/Validator.js
+++ b/src/components/VanillaTreeViewer/Validator/Validator.js
@@ -3,6 +3,7 @@ import {
   HLJS_LANGUAGES,
   HLJS_VERSION
 } from 'components/VanillaTreeViewer/hljs';
+import { normalizePath } from 'components/VanillaTreeViewer/Tree/Builder/Builder';
 
 function filesIsArray(files) {
   return typeof files === 'object' && files !== null;
@@ -36,6 +37,72 @@ function hasUrlOrContentsPresent(files) {
   return badFileCount === 0;
 }
 
+/*
+ * Verifies whether all combinations of subpaths are compatible and
+ * unambiguous.
+ *
+ * For example, the following list of paths is NOT valid:
+ *
+ *  * /alpha/beta/gamma.rb
+ *  * /alpha/BETA/delta.rb
+ *
+ * Since directories are case-sensitive, we have an ambigous definition
+ * of `/alpha/beta` vs `/alpha/BETA`.
+ */
+function allFilesHaveUnambiguousSubPaths(files) {
+  let subpaths = new Set();
+
+  /*
+   * Build a cumulative list of every subsubpath, case sensitively
+   *
+   *  INPUT:
+   *  '/alpha/BETA/gamma.rb' will result in:
+   *
+   *  OUTPUT:
+   *  [
+   *    '/',
+   *    '/alpha',
+   *    '/alpha/BETA'
+   *  ]
+   */
+  files.forEach((file) => {
+    const segments = normalizePath(file.path).split('/');
+
+    // Ignore the filename, which is the last segment
+    segments.pop();
+
+    let builder = '';
+
+    segments.forEach((segment) => {
+      builder += `/${segment}`;
+      subpaths.add(builder);
+    });
+  });
+
+  /*
+   * Check if all values are case sensitively unique. If they
+   * are not, at least one subpath exists with multiple cases
+   * (e.g. '/foo/bar' vs '/foo/BAR')
+   */
+  subpaths = Array.from(subpaths).map((p) => p.toLowerCase());
+  const uniqueSubpaths = subpaths.filter(
+    (value, idx, self) => self.indexOf(value) === idx
+  );
+
+  return uniqueSubpaths.length === subpaths.length;
+}
+
+/*
+ * Verifies that all `path` values are unique, regardless of case.
+ * For example, the following is not valid
+ *
+ *  * /alpha/beta/gamma.rb
+ *  * /alpha/beta/GAMMA.rb
+ *
+ * A previous validation already checks for unambiguous directories,
+ * so we don't have to re-check that here. We just need
+ * to verify that no two paths differ by only their case.
+ */
 function allFilesHaveUniquePaths(files) {
   const paths = files.map((file) => file.path.toLowerCase());
   const uniquePaths = paths.filter(
@@ -103,6 +170,20 @@ function handleUrlOrContentsBlank() {
   };
 }
 
+function handleFilesHaveAmbiguousSubpaths() {
+  return {
+    isValid: false,
+    error: `One or more \`path\` values have ambiguous directory names.
+
+For example:
+
+  * /alpha/beta/gamma.txt
+  * /alpha/BETA/delta.text
+
+Since directories are case sensitive, this produces an ambiguous definition of '/alpha/beta/' vs '/alpha/BETA'.`
+  };
+}
+
 function handleFilesHaveDuplicatePaths() {
   return {
     isValid: false,
@@ -148,6 +229,9 @@ function validateFiles(files) {
   }
   if (!hasUrlOrContentsPresent(files)) {
     return handleUrlOrContentsBlank();
+  }
+  if (!allFilesHaveUnambiguousSubPaths(files)) {
+    return handleFilesHaveAmbiguousSubpaths();
   }
   if (!allFilesHaveUniquePaths(files)) {
     return handleFilesHaveDuplicatePaths();

--- a/src/components/VanillaTreeViewer/Validator/Validator.test.js
+++ b/src/components/VanillaTreeViewer/Validator/Validator.test.js
@@ -111,6 +111,24 @@ describe('Validator.validateFiles', () => {
     it('marks the files as invalid', testForInvalid);
   });
 
+  describe('multiple files exist with ambiguous directories', () => {
+    beforeEach(() => {
+      const segments0 = files[0].path.split('/');
+      const segments1 = files[1].path.split('/');
+
+      /*
+       * Object files[1] should have the same directory as files[0], but with
+       * different case and its original filename
+       */
+      segments0.pop();
+      files[1].path = [segments0.join('/').toUpperCase(), segments1.pop()].join(
+        '/'
+      );
+    });
+
+    it('marks the files as invalid', testForInvalid);
+  });
+
   describe('files object is duplicate paths', () => {
     beforeEach(() => {
       files[1].path = files[0].path;


### PR DESCRIPTION
5e3f2fd Add validation to enforce unambiguous sub-paths
eab91c4 Preserve original case on user-specified `path`