### PR TITLE
Remove requirement to defer `renderAll()` until `DOMContentLoaded`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
 
 # <a name="install"></a>Install
 
-**Import** the latest **script** and **styling** ([See all versions](https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@master/dist/))
+Import the latest **script** and **styling** ([See all versions](https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@master/dist/))
 
 ```html
 <head>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@2.0.0/dist/index.min.js"></script>
+  <!-- Note the `onload` call within the `<script>` tag. -->
+  <script type="text/javascript" onload="VanillaTreeViewer.renderAll()" src="https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@2.0.0/dist/index.min.js"></script>
+
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@2.0.0/dist/main.min.css">
 </head>
 ```
@@ -59,7 +61,7 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
 
 💡 To run this example locally, clone this project and open [`examples/quick_start.html`](examples/quick_start.html).
 
-① **Define** the list of files as an HTML list (`<ol>`). You **must** include the `.vtv` CSS class.
+**Define** the list of files as an HTML list (`<ol>`). You **must** include the `.vtv` CSS class.
 
 (For a full list of `data-*` attribute options, see [Options](#options))
 
@@ -80,16 +82,6 @@ Perfect for blog posts ([like this one](https://abhchand.me/blog/use-react-in-ra
   <!-- File 3 -->
   ...
 </ol>
-```
-
-② **Render** all instances by calling `VanillaTreeViewer.renderAll()` after page load.
-
-```html
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    VanillaTreeViewer.renderAll();
-  }, false);
-</script>
 ```
 
 # <a name="syntax-highlighting"></a>Syntax Highlighting

--- a/README.md
+++ b/README.md
@@ -59,30 +59,32 @@ Import the latest **script** and **styling** ([See all versions](https://cdn.jsd
 
 # <a name="usage"></a>Usage
 
-💡 To run this example locally, clone this project and open [`examples/quick_start.html`](examples/quick_start.html).
-
-**Define** the list of files as an HTML list (`<ol>`). You **must** include the `.vtv` CSS class.
-
-(For a full list of `data-*` attribute options, see [Options](#options))
+Define the list of files and their contents as an HTML list (`<ol>`). You **must** include the `.vtv` CSS class.
 
 ```html
 <ol class='vtv' data-language="javascript">
   <!-- File 1 -->
-  <!-- File contents will be fetched from `data-url` -->
+  <!-- Fetch file contents from `data-url` -->
   <li
     data-path="lib/axios.js"
     data-url="https://raw.githubusercontent.com/axios/axios/master/lib/axios.js">
   </li>
 
   <!-- File 2 -->
-  <!-- You can specify the file contents directly inside `<li>...</li>` -->
-  <!-- You can override syntax highlighting with `data-language` for this file -->
+  <!-- Alternately, you can specify the file contents directly inside `<li>...</li>` -->
+  <!-- You can also override syntax highlighting with `data-language` for this file -->
   <li data-path="values.json" data-language="json">{ "foo": "bar" }</li>
 
   <!-- File 3 -->
   ...
 </ol>
 ```
+
+For a full list of `data-*` attribute options, see [Options](#options)
+
+💡 To run this example locally, clone this project and open [`examples/quick_start.html`](examples/quick_start.html).
+
+▶️ To run this example on codepen, [click here](https://codepen.io/abhchand/pen/WNZGQpQ)
 
 # <a name="syntax-highlighting"></a>Syntax Highlighting
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,10 +2,9 @@ import './template.scss';
 import Logo from './logo.svg';
 
 import VanillaTreeViewer from '../src/components/VanillaTreeViewer/VanillaTreeViewer';
+VanillaTreeViewer.renderAll();
 
 document.addEventListener('DOMContentLoaded', function() {
   // Load SVG logo
   document.querySelector('.logo-link').innerHTML = Logo;
-
-  VanillaTreeViewer.renderAll();
 }, false);

--- a/examples/quick_start.html
+++ b/examples/quick_start.html
@@ -11,15 +11,8 @@
     </style>
 
     <!-- Include VanillaTreeViewer JS and CSS -->
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@2.0.0/dist/index.min.js"></script>
+    <script type="text/javascript" onload="VanillaTreeViewer.renderAll()" src="https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@2.0.0/dist/index.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/abhchand/vanilla-tree-viewer@2.0.0/dist/main.min.css">
-
-    <!-- Render all VanillaTreeViewer instances after page load -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        VanillaTreeViewer.renderAll();
-      }, false);
-    </script>
   </head>
   <body>
     <h3 class="heading">

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.js
@@ -14,12 +14,47 @@ import Store from 'lib/Store/Store';
 import { validateFiles } from './Validator/Validator';
 
 class VanillaTreeViewer extends Component {
+  /*
+   * Top-level API used to render a VanillaTreeViewer instance on top
+   * of each user-defined HTML node.
+   *
+   * This function is idempotent, so it can be called repeatedly as
+   * new user-defined HTML nodes are added to the document.
+   */
   static renderAll() {
     /*
-     * Extract configuration from each user-defined node
-     * and render a `VanillaTreeViewer` instance on that node
+     * Define the rendering function, which will:
+     *   1. Parse/extract configuration from each user-defined node and
+     *   2. Render a `VanillaTreeViewer` instance on that node
      */
-    parseUserNodes().forEach((args) => new VanillaTreeViewer(...args).render());
+    const perform = () => {
+      parseUserNodes().forEach((args) =>
+        new VanillaTreeViewer(...args).render()
+      );
+    };
+
+    /*
+     * We want to ensure the DOM content is fully loaded and all scripts are
+     * loaded before running the above.
+     *
+     * Check the current state of the page and either run it now if it's ready,
+     * or defer execution until the page is done loading content.
+     *
+     * See https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState
+     */
+    if (document.readyState === 'complete') {
+      perform();
+    } else {
+      document.onreadystatechange = () => {
+        /*
+         * Check if page is about to transition from
+         * `interactive` -> `complete`
+         */
+        if (document.readyState === 'interactive') {
+          perform();
+        }
+      };
+    }
   }
 
   constructor(id, files) {

--- a/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
+++ b/src/components/VanillaTreeViewer/VanillaTreeViewer.test.js
@@ -521,6 +521,12 @@ const render = () => {
   const parentNode = buildNodes();
   document.body.appendChild(parentNode);
 
+  /*
+   * `document.readyState` should already be `complete` so `renderAll`
+   * renders immediately, but confirm that explicitly
+   */
+  expect(document.readyState).to.equal('complete');
+
   VanillaTreeViewer.renderAll();
 
   return rendered();


### PR DESCRIPTION
Till now, users were instructed to call `VanillaTreeViewer.renderAll()`
manually, after the DOM Content loaded:

```html
<script>
  document.addEventListener('DOMContentLoaded', function() {
    VanillaTreeViewer.renderAll();
  }, false);
</script>
```

To make this simpler, `renderAll()` will correctly delay itself till DOM
content has loaded, and users no longer need to worry about implementing the
above.

Additionally, the official documentation now suggests calling `renderAll()` on
script load so it doesn't have to be called separately as a one-off statement.

```html
<!-- Note the `onload` call within the `<script>` tag. -->
<script
  type="text/javascript"
  onload="VanillaTreeViewer.renderAll()"
  src="..."
</script>
```